### PR TITLE
Fix issue with newlines not displaying from claude-auto command

### DIFF
--- a/functions/claude-pretty-parser.fish
+++ b/functions/claude-pretty-parser.fish
@@ -119,7 +119,7 @@ function claude-pretty-parser
                 if test -n "$tool_result"
                     # Use the simple approach that works for file creation
                     echo "[$timestamp] 📄 Tool result:"
-                    echo "$tool_result"
+                    echo $line | jq -r '.message.content[]? | select(.type == "tool_result") | .content // ""'
                     echo "[$timestamp] ---"
                 end
                 


### PR DESCRIPTION
Changed line 122 to pipe jq output directly instead of storing in a variable
first. This preserves newlines in tool results, fixing the issue where
multi-line file content was displayed on a single line.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
